### PR TITLE
Timetable frontend

### DIFF
--- a/app/Http/Controllers/StundenController.php
+++ b/app/Http/Controllers/StundenController.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class StundenController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        $days = ["Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag"];
+        $hours_pairs = [
+            ["08:15", "09:45"],
+            ["10:00", "11:30"],
+            ["11:45", "13:15"],
+            ["14:15" , "15:45"],
+            ["16:00", "17:30"],
+            ["17:45", "19:15"],
+            ["19:30", "21:00"]
+        ];
+
+        return view('stundenplan.plan_doz', compact('days', 'hours_pairs'));
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(string $id)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(string $id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, string $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $id)
+    {
+        //
+    }
+}

--- a/app/Http/Middleware/DozentMiddleware.php
+++ b/app/Http/Middleware/DozentMiddleware.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Support\Facades\Auth;
+
+class DozentMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param Closure(Request): (Response) $next
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        if (Auth::check() && Auth::user()->dozent) {
+            return $next($request);
+        }
+
+        return redirect('/dashboard'); // redirect non-dozenten
+    }
+}

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -175,3 +175,154 @@
     background-color: var(--blue);
     color: white;
 }
+
+/*----------------------------------------------------Stundenplan----------------------------------------------------*/
+.timetable_page {
+    display: grid;
+    grid-template-columns: 25% 75%;
+}
+
+.timetable_page:first-of-type {
+    left: 50%;
+    transform: translateX(-50%);
+}
+
+.sidebar {
+    box-shadow: 0 0 10px rgba(114, 114, 113, 0.5);
+    border-radius: 2rem;
+    padding: 1rem;
+    margin-right: 1em;
+    background-color: white;
+    display: inline-block;
+    height: fit-content;
+}
+
+.sidebar_header {
+    padding: 0 .9rem;
+    display: flex;
+    justify-content: space-between;
+}
+
+.sidebar_courses {
+    max-height: 60vh;
+    overflow-y: auto;
+    padding: .75rem .75rem 0;
+}
+
+.subject {
+    padding: .75rem;
+    margin: 1rem 0;
+    border-radius: 1rem;
+    background-color: var(--blue_bg);
+    cursor: pointer;
+    position: relative;
+    box-shadow: 0 2px 0 var(--blue);
+    z-index: 4;
+}
+
+.subject::after {
+    content: '';
+    position: absolute;
+    width: 0;
+    top: 0;
+    left: 50%;
+    border-radius: 0 0 1rem 1rem;
+    background-color: var(--blue);
+    transition: .1s;
+}
+
+.subject:hover::after,
+.subject:focus-within::after {
+    width: 70%;
+    left: 15%;
+    height: .3rem;
+    transition: .1s;
+}
+
+.dropped-subject {
+    width: 98%;
+    height: 100%;
+    padding: .75rem;
+    margin: 0 1%;
+    border-radius: 0;
+    background-color: var(--blue_bg);
+    box-shadow: none;
+    z-index: 3;
+    cursor: pointer;
+}
+
+.timetable {
+    height: 100%;
+    background-color: #fff;
+    display: inline-block;
+    border-radius: 2rem;
+    overflow: hidden;
+    box-shadow: 0 0 10px rgba(114, 114, 113, 0.5);
+}
+
+.timetable_content {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.timetable_head {
+    box-shadow: 0 3px 3px var(--green);
+}
+
+.timetable_content th,
+.timetable_content td {
+    border: 2px solid #838383;
+    padding: .7rem;
+    text-align: center;
+    position: relative;
+    max-width: 40px;
+}
+
+.timetable_content .timetable_data:empty {
+    padding: .7rem;
+}
+
+.timetable_content .timetable_data {
+    padding: 0;
+}
+
+.timetable_content th {
+    border-top: none;
+}
+
+/*
+ * remove outer borders
+ */
+.timetable_content th:first-of-type,
+.timetable_content th:last-of-type,
+.timetable_content td:first-of-type,
+.timetable_content td:last-of-type {
+    border-left: none;
+    border-right: none;
+}
+
+.timetable_content tr:last-of-type td {
+    border-bottom: none;
+}
+
+.timetable_content td {
+    position: relative;
+    /* Ermöglicht absolute Positionierung der Module */
+}
+
+/* Beispielfarben für Fächer in der Tabelle */
+.dropped-subject:nth-child(1) {
+    background-color: var(--green);
+}
+
+.dropped-subject:nth-child(2) {
+    background-color: #ff9800;
+}
+
+.dropped-subject:nth-child(3) {
+    background-color: var(--blue);
+}
+
+.dropped-subject:nth-child(4) {
+    background-color: #9c27b0;
+}

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -8,6 +8,8 @@
     --green:#B3C91B;
     --green_bg: #e3e4d5;
     --red: #C62828;
+    --orange: #ff9800;
+    --purple: #9c27b0;
 }
 
 /*----------------------------------------------------Admin Pages----------------------------------------------------*/
@@ -213,11 +215,23 @@
     padding: .75rem;
     margin: 1rem 0;
     border-radius: 1rem;
-    background-color: var(--blue_bg);
+    background-color: var(--green);
     cursor: pointer;
     position: relative;
-    box-shadow: 0 2px 0 var(--blue);
+    box-shadow: 0 2px 0 var(--green_bg);
     z-index: 4;
+}
+
+.subject[draggable="false"] {
+    cursor: default;
+}
+
+.sidebar_courses .subject[draggable="false"] {
+    opacity: 0.6;
+}
+
+.subject[draggable="false"]::after {
+    display: none;
 }
 
 .subject::after {
@@ -226,6 +240,7 @@
     width: 0;
     top: 0;
     left: 50%;
+    height: 0;
     border-radius: 0 0 1rem 1rem;
     background-color: var(--blue);
     transition: .1s;
@@ -241,7 +256,7 @@
 
 .dropped-subject {
     width: 98%;
-    height: 100%;
+    height: fit-content;
     padding: .75rem;
     margin: 0 1%;
     border-radius: 0;
@@ -249,6 +264,17 @@
     box-shadow: none;
     z-index: 3;
     cursor: pointer;
+}
+
+.dropped-subject::after {
+    background-color: var(--blue);
+}
+
+.dropped-subject p {
+    width: 105%;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
 }
 
 .timetable {
@@ -263,10 +289,6 @@
 .timetable_content {
     width: 100%;
     border-collapse: collapse;
-}
-
-.timetable_head {
-    box-shadow: 0 3px 3px var(--green);
 }
 
 .timetable_content th,
@@ -286,8 +308,20 @@
     padding: 0;
 }
 
+.timetable_content .timetable_time {
+    background-color: var(--blue_bg);
+    border-color: #575757;
+}
+
 .timetable_content th {
     border-top: none;
+    background-color: var(--blue);
+    color: white;
+    border-color: #575757;
+}
+
+.hovered {
+    background-color: var(--green_bg);
 }
 
 /*
@@ -306,6 +340,7 @@
 }
 
 .timetable_content td {
+    height: 6.4rem;
     position: relative;
     /* Ermöglicht absolute Positionierung der Module */
 }
@@ -316,13 +351,15 @@
 }
 
 .dropped-subject:nth-child(2) {
-    background-color: #ff9800;
+    background-color: var(--orange);
 }
 
 .dropped-subject:nth-child(3) {
-    background-color: var(--blue);
+    background-color: var(--red);
+    color: white;
 }
 
 .dropped-subject:nth-child(4) {
-    background-color: #9c27b0;
+    background-color: var(--purple);
+    color: white;
 }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -342,24 +342,24 @@
 .timetable_content td {
     height: 6.4rem;
     position: relative;
-    /* Ermöglicht absolute Positionierung der Module */
 }
 
-/* Beispielfarben für Fächer in der Tabelle */
-.dropped-subject:nth-child(1) {
+.color-1 {
     background-color: var(--green);
+    color: black;
 }
 
-.dropped-subject:nth-child(2) {
+.color-2 {
     background-color: var(--orange);
+    color: black;
 }
 
-.dropped-subject:nth-child(3) {
+.color-3 {
     background-color: var(--red);
     color: white;
 }
 
-.dropped-subject:nth-child(4) {
+.color-4 {
     background-color: var(--purple);
     color: white;
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -5,3 +5,309 @@ import Alpine from 'alpinejs';
 window.Alpine = Alpine;
 
 Alpine.start();
+
+document.addEventListener('DOMContentLoaded', () => {
+    // select the timetable, all subjects, and all timetable cells
+    const timetable = document.querySelector('.timetable');
+    const subjects = document.querySelectorAll('.subject');
+    const timetableCells = document.querySelectorAll('.timetable td');
+
+    // make each subject draggable.
+    subjects.forEach(subject => {
+        makeDraggable(subject);
+    });
+
+    // add drag and drop event listeners to each timetable cell
+    timetableCells.forEach(cell => {
+        cell.addEventListener('dragover', dragOver);
+        cell.addEventListener('dragenter', dragEnter);
+        cell.addEventListener('dragleave', dragLeave);
+        cell.addEventListener('drop', dragDrop);
+    });
+
+    // add a click event listener to the timetable to handle the removal of subjects
+    timetable.addEventListener('click', (event) => {
+        const subjectElement = event.target.closest('.subject');
+        if (subjectElement && !subjectElement.classList.contains('cloned')) {
+            removeModule(subjectElement);
+        }
+    });
+
+    // subject currently being dragged
+    let draggedSubject = null;
+
+    /**
+     * Makes a subject draggable.
+     * @param {HTMLElement} subject - The subject to make draggable.
+     */
+    function makeDraggable(subject) {
+        subject.setAttribute('draggable', 'true');
+        subject.addEventListener('dragstart', dragStart);
+        subject.addEventListener('dragend', dragEnd);
+    }
+
+    /**
+     * Handles the drag start event.
+     * @param {DragEvent} event - The drag event.
+     */
+    function dragStart(event) {
+        draggedSubject = this;
+        event.dataTransfer.effectAllowed = 'move';
+        event.dataTransfer.setData('text/plain', this.textContent);
+        event.dataTransfer.setData('length', this.dataset.length);
+        this.classList.add('dragging');
+    }
+
+    /**
+     * Handles the drag end event.
+     */
+    function dragEnd() {
+        this.classList.remove('dragging');
+    }
+
+    /**
+     * Handles the drag over event.
+     * @param {DragEvent} event - The drag event.
+     */
+    function dragOver(event) {
+        event.preventDefault();
+        event.dataTransfer.dropEffect = 'move';
+    }
+
+    /**
+     * Handles the drag enter event.
+     * @param {DragEvent} event - The drag event.
+     */
+    function dragEnter(event) {
+        event.preventDefault();
+        this.classList.add('hovered');
+    }
+
+    /**
+     * Handles the drag leave event.
+     */
+    function dragLeave() {
+        this.classList.remove('hovered');
+    }
+
+    /**
+     * Handles the drop event when a subject is dropped onto a timetable cell.
+     * @param {DragEvent} event - The drag event.
+     */
+    function dragDrop(event) {
+        event.preventDefault();
+        const subjectLength = parseFloat(event.dataTransfer.getData('length'));
+        const { startTime, endTime, day } = getTimeAndDayFromCell(this, subjectLength);
+
+        if (isValidDropTarget(this, subjectLength)) {
+            const newSubject = draggedSubject.cloneNode(true);
+            newSubject.classList.add('dropped-subject');
+            newSubject.dataset.startTime = startTime;
+            newSubject.dataset.endTime = endTime;
+            newSubject.dataset.day = day;
+            newSubject.dataset.subjectId = draggedSubject.dataset.subjectId;
+
+            let timeSpan = newSubject.querySelector('.time-span');
+            if (!timeSpan) {
+                timeSpan = document.createElement('div');
+                timeSpan.classList.add('time-span');
+                newSubject.insertBefore(timeSpan, newSubject.firstChild);
+            }
+            timeSpan.textContent = `${startTime} - ${endTime}`;
+
+            this.appendChild(newSubject);
+            makeDraggable(newSubject);
+
+            const originalParentCell = draggedSubject.parentNode;
+            if (originalParentCell !== this) {
+                removeSubjectAndClones(originalParentCell, parseFloat(draggedSubject.dataset.length));
+            }
+
+            let currentCell = this;
+            for (let i = 1; i < subjectLength; i++) {
+                currentCell = getNextCell(currentCell);
+                if (currentCell) {
+                    const clone = newSubject.cloneNode(true);
+                    clone.classList.add('cloned');
+                    clone.dataset.startTime = startTime;
+                    clone.dataset.endTime = endTime;
+                    clone.dataset.day = day;
+                    currentCell.appendChild(clone);
+                } else {
+                    break;
+                }
+            }
+
+            highlightOriginal(newSubject);
+        }
+
+        this.classList.remove('hovered');
+    }
+
+    /**
+     * Checks if a cell is a valid drop target for a subject of a given length.
+     * @param {HTMLElement} cell - The cell to check.
+     * @param {number} length - The length of the subject.
+     * @returns {boolean} - Whether the cell is a valid drop target.
+     */
+    function isValidDropTarget(cell, length) {
+        const cellIndex = Array.from(timetableCells).indexOf(cell);
+        const colIndex = cellIndex % 7;
+
+        if (colIndex === 0) {
+            return false;
+        }
+
+        let remainingLength = length;
+        let currentCell = cell;
+        while (remainingLength > 0 && currentCell) {
+            const currentCellIndex = Array.from(timetableCells).indexOf(currentCell);
+            const currentColIndex = currentCellIndex % 7;
+
+            if (currentColIndex === 0) {
+                currentCell = getNextCell(currentCell);
+                continue;
+            }
+
+            const existingSubject = currentCell.querySelector('.dropped-subject');
+            if (existingSubject && parseFloat(existingSubject.dataset.length) > 1) {
+                remainingLength--;
+            } else if (!currentCell.classList.contains('blocked')) {
+                remainingLength--;
+            }
+            currentCell = getNextCell(currentCell);
+        }
+
+        return remainingLength === 0;
+    }
+
+    /**
+     * Returns the next cell in the timetable.
+     * @param {HTMLElement} cell - The current cell.
+     * @returns {HTMLElement|null} - The next cell in the timetable, or null if there is no next cell.
+     */
+    function getNextCell(cell) {
+        const cellIndex = Array.from(timetableCells).indexOf(cell);
+        const rowIndex = Math.floor(cellIndex / 7);
+        const nextRowIndex = rowIndex + 1;
+
+        if (nextRowIndex * 7 >= timetableCells.length) {
+            return null;
+        } else {
+            return timetableCells[nextRowIndex * 7 + (cellIndex % 7)];
+        }
+    }
+
+    /**
+     * Returns the start time, end time, and day for a given cell and subject length.
+     * @param {HTMLElement} cell - The cell.
+     * @param {number} length - The length of the subject.
+     * @returns {Object} - An object containing the start time, end time, and day.
+     */
+    function getTimeAndDayFromCell(cell, length) {
+        const cellIndex = Array.from(timetableCells).indexOf(cell);
+        const row = cell.parentElement;
+        const startTimeText = row.querySelector('td:first-child').textContent.split(' - ')[0];
+        const endTimeText = calculateEndTime(startTimeText, length);
+        const day = cellIndex - 1;
+        return { startTime: startTimeText, endTime: endTimeText, day };
+    }
+
+    /**
+     * Calculates the end time for a subject given its start time and length.
+     * @param {string} startTime - The start time of the subject.
+     * @param {number} length - The length of the subject.
+     * @returns {string} - The end time of the subject.
+     */
+    function calculateEndTime(startTime, length) {
+        const [startHour, startMinute] = startTime.split(':').map(Number);
+
+        let additionalMinutes = 0;
+        if (length === 2) {
+            additionalMinutes = 15;
+        } else if (length === 3) {
+            additionalMinutes = 30;
+        } else if (length > 3) {
+            additionalMinutes = 45 * (length - 1);
+        }
+
+        let totalMinutes = startMinute + (length * 90) + additionalMinutes;
+        if (length === 2 && startTime === '11:45') {
+            totalMinutes += 45;
+        }
+        let endHour = startHour + Math.floor(totalMinutes / 60);
+        let endMinute = totalMinutes % 60;
+
+        if (endMinute < 10) {
+            endMinute = '0' + endMinute;
+        }
+
+        return `${endHour}:${endMinute}`;
+    }
+
+    /**
+     * Highlights the original subject element and removes the highlight from all other subjects.
+     * @param {HTMLElement} subjectElement - The subject element to highlight.
+     */
+    function highlightOriginal(subjectElement) {
+        subjects.forEach(subject => {
+            subject.classList.remove('highlighted');
+        });
+        subjectElement.classList.add('highlighted');
+    }
+
+    /**
+     * Removes a subject element from its parent cell and unblocks the cells it occupied.
+     * @param {HTMLElement} subjectElement - The subject element to remove.
+     */
+    function removeModule(subjectElement) {
+        const parentCell = subjectElement.parentNode;
+        parentCell.removeChild(subjectElement);
+
+        let currentCell = parentCell;
+        const subjectLength = parseFloat(subjectElement.dataset.length);
+        for (let i = 1; i < subjectLength; i++) {
+            currentCell = getNextCell(currentCell);
+            if (currentCell) {
+                // unblock the cell
+                currentCell.classList.remove('blocked');
+                // remove any cloned elements from the cell
+                const clonedElement = currentCell.querySelector('.cloned');
+                if (clonedElement) {
+                    currentCell.removeChild(clonedElement);
+                }
+            }
+        }
+    }
+
+    /**
+     * Removes a subject and its clones from a cell and unblocks the cells they occupied.
+     * @param {HTMLElement} cell - The cell to remove the subject and its clones from.
+     * @param {number} length - The length of the subject.
+     */
+    function removeSubjectAndClones(cell, length) {
+        let currentCell = cell;
+        let removedSubjects = 0;
+
+        while (removedSubjects < length && currentCell) {
+            const subject = currentCell.querySelector('.dropped-subject, .cloned');
+            if (subject) {
+                currentCell.removeChild(subject);
+                currentCell.classList.remove('blocked');
+                removedSubjects++;
+            }
+            currentCell = getNextCell(currentCell);
+        }
+    }
+
+    function addFieldsetForCourse() {
+        const formTemplate = document.getElementById('course-form-template').content.cloneNode(true);
+        /*
+         * clones a fieldset with the following inputs:
+         * subject_id - id of the course (int - min 0)
+         * start_time - start time of the course (HH:MM - min 08:00, max 21:00)
+         * day - day of the week the course is on
+         */
+
+    }
+});

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -7,331 +7,339 @@ window.Alpine = Alpine;
 Alpine.start();
 
 document.addEventListener('DOMContentLoaded', () => {
+
+    /*
+     * -------- TIMETABLE DRAG AND DROP --------
+     */
+
     // select the timetable, all subjects, and all timetable cells
     const timetable = document.querySelector('.timetable');
-    const subjects = document.querySelectorAll('.subject');
-    const timetableCells = document.querySelectorAll('.timetable td');
 
-    // make each subject draggable.
-    subjects.forEach(subject => {
-        makeDraggable(subject);
-    });
+    if (timetable) {
+        const subjects = document.querySelectorAll('.subject');
+        const timetableCells = document.querySelectorAll('.timetable td');
 
-    // add drag and drop event listeners to each timetable cell
-    timetableCells.forEach(cell => {
-        cell.addEventListener('dragover', dragOver);
-        cell.addEventListener('dragenter', dragEnter);
-        cell.addEventListener('dragleave', dragLeave);
-        cell.addEventListener('drop', dragDrop);
-    });
+        // make each subject draggable.
+        subjects.forEach(subject => {
+            makeDraggable(subject);
+        });
 
-    // add a click event listener to the timetable to handle the removal of subjects
-    timetable.addEventListener('click', (event) => {
-        const subjectElement = event.target.closest('.subject');
-        if (subjectElement && !subjectElement.classList.contains('cloned')) {
-            removeModule(subjectElement);
+        // add drag and drop event listeners to each timetable cell
+        timetableCells.forEach(cell => {
+            cell.addEventListener('dragover', dragOver);
+            cell.addEventListener('dragenter', dragEnter);
+            cell.addEventListener('dragleave', dragLeave);
+            cell.addEventListener('drop', dragDrop);
+        });
+
+        // add a click event listener to the timetable to handle the removal of subjects
+        timetable.addEventListener('click', (event) => {
+            const subjectElement = event.target.closest('.subject');
+            if (subjectElement && !subjectElement.classList.contains('cloned')) {
+                removeModule(subjectElement);
+            }
+        });
+
+        // subject currently being dragged
+        let draggedSubject = null;
+
+        /**
+         * Makes a subject draggable.
+         * @param {HTMLElement} subject - The subject to make draggable.
+         */
+        function makeDraggable(subject) {
+            subject.setAttribute('draggable', 'true');
+            subject.addEventListener('dragstart', dragStart);
+            subject.addEventListener('dragend', dragEnd);
         }
-    });
 
-    // subject currently being dragged
-    let draggedSubject = null;
+        function makeUnDraggable(subject) {
+            subject.setAttribute('draggable', 'false');
+            subject.removeEventListener('dragstart', dragStart);
+            subject.removeEventListener('dragend', dragEnd);
+        }
 
-    /**
-     * Makes a subject draggable.
-     * @param {HTMLElement} subject - The subject to make draggable.
-     */
-    function makeDraggable(subject) {
-        subject.setAttribute('draggable', 'true');
-        subject.addEventListener('dragstart', dragStart);
-        subject.addEventListener('dragend', dragEnd);
-    }
+        /**
+         * Handles the drag start event.
+         * @param {DragEvent} event - The drag event.
+         */
+        function dragStart(event) {
+            draggedSubject = this;
+            event.dataTransfer.effectAllowed = 'move';
+            event.dataTransfer.setData('text/plain', this.textContent);
+            event.dataTransfer.setData('length', this.dataset.length);
+            this.classList.add('dragging');
+        }
 
-    function makeUnDraggable(subject) {
-        subject.setAttribute('draggable', 'false');
-        subject.removeEventListener('dragstart', dragStart);
-        subject.removeEventListener('dragend', dragEnd);
-    }
+        /**
+         * Handles the drag end event.
+         */
+        function dragEnd() {
+            this.classList.remove('dragging');
+        }
 
-    /**
-     * Handles the drag start event.
-     * @param {DragEvent} event - The drag event.
-     */
-    function dragStart(event) {
-        draggedSubject = this;
-        event.dataTransfer.effectAllowed = 'move';
-        event.dataTransfer.setData('text/plain', this.textContent);
-        event.dataTransfer.setData('length', this.dataset.length);
-        this.classList.add('dragging');
-    }
+        /**
+         * Handles the drag over event.
+         * @param {DragEvent} event - The drag event.
+         */
+        function dragOver(event) {
+            event.preventDefault();
+            event.dataTransfer.dropEffect = 'move';
+        }
 
-    /**
-     * Handles the drag end event.
-     */
-    function dragEnd() {
-        this.classList.remove('dragging');
-    }
+        /**
+         * Handles the drag enter event.
+         * @param {DragEvent} event - The drag event.
+         */
+        function dragEnter(event) {
+            event.preventDefault();
+            this.classList.add('hovered');
+        }
 
-    /**
-     * Handles the drag over event.
-     * @param {DragEvent} event - The drag event.
-     */
-    function dragOver(event) {
-        event.preventDefault();
-        event.dataTransfer.dropEffect = 'move';
-    }
+        /**
+         * Handles the drag leave event.
+         */
+        function dragLeave() {
+            this.classList.remove('hovered');
+        }
 
-    /**
-     * Handles the drag enter event.
-     * @param {DragEvent} event - The drag event.
-     */
-    function dragEnter(event) {
-        event.preventDefault();
-        this.classList.add('hovered');
-    }
+        /**
+         * Handles the drop event when a subject is dropped onto a timetable cell.
+         * @param {DragEvent} event - The drag event.
+         */
+        function dragDrop(event) {
+            event.preventDefault();
+            const subjectLength = parseFloat(event.dataTransfer.getData('length'));
+            const { startTime, endTime, day } = getTimeAndDayFromCell(this, subjectLength);
 
-    /**
-     * Handles the drag leave event.
-     */
-    function dragLeave() {
-        this.classList.remove('hovered');
-    }
+            // check if the subject is already in the timetable
+            const isSubjectInTimetable = checkIfSubjectIsInTimetable(draggedSubject.dataset.subjectId);
 
-    /**
-     * Handles the drop event when a subject is dropped onto a timetable cell.
-     * @param {DragEvent} event - The drag event.
-     */
-    function dragDrop(event) {
-        event.preventDefault();
-        const subjectLength = parseFloat(event.dataTransfer.getData('length'));
-        const { startTime, endTime, day } = getTimeAndDayFromCell(this, subjectLength);
+            if (isValidDropTarget(this, subjectLength)) {
+                let newSubject = null;
 
-        // check if the subject is already in the timetable
-        const isSubjectInTimetable = checkIfSubjectIsInTimetable(draggedSubject.dataset.subjectId);
-
-        if (isValidDropTarget(this, subjectLength)) {
-            let newSubject = null;
-
-            if (isSubjectInTimetable && draggedSubject.classList.contains('dropped-subject')) {
-                // if the subject is already in the timetable and we're moving it
-                newSubject = draggedSubject;
-                removeSubjectAndClones(draggedSubject.parentElement, parseFloat(draggedSubject.dataset.length), draggedSubject.dataset.subjectId);
-            } else if (isSubjectInTimetable) {
-                // if the subject is in the timetable, but we're trying to add it again
-                this.classList.remove('hovered');
-                return;
-            } else {
-                // if it's a new subject being added to the timetable
-                newSubject = document.createElement('div');
-                newSubject.className = draggedSubject.className;
-                newSubject.classList.add('dropped-subject');
-                newSubject.dataset.subjectId = draggedSubject.dataset.subjectId;
-                newSubject.dataset.length = subjectLength.toString();
-
-                // clone only p elements with class 'course_name' & 'course_stdg'
-                draggedSubject.querySelectorAll('p.course_name, p.course_stdg').forEach(p => {
-                    newSubject.appendChild(p.cloneNode(true));
-                });
-            }
-
-            if (newSubject === null) {
-                return;
-            }
-
-            // Update the subject's time and day information
-            newSubject.dataset.startTime = startTime;
-            newSubject.dataset.endTime = endTime;
-            newSubject.dataset.day = day.toString();
-
-            // update or create the time span
-            let timeSpan = newSubject.querySelector('.time-span');
-            if (!timeSpan) {
-                timeSpan = document.createElement('div');
-                timeSpan.classList.add('time-span');
-                newSubject.insertBefore(timeSpan, newSubject.firstChild);
-            }
-            timeSpan.textContent = `${startTime} - ${endTime}`;
-
-            this.appendChild(newSubject);
-            makeUnDraggable(draggedSubject);
-            makeDraggable(newSubject);
-
-            // create clones for multi-cell subjects
-            let currentCell = this;
-            for (let i = 1; i < subjectLength; i++) {
-                currentCell = getNextCell(currentCell);
-                if (currentCell) {
-                    const clone = newSubject.cloneNode(true);
-                    makeUnDraggable(clone)
-                    clone.classList.add('cloned');
-                    currentCell.appendChild(clone);
+                if (isSubjectInTimetable && draggedSubject.classList.contains('dropped-subject')) {
+                    // if the subject is already in the timetable and we're moving it
+                    newSubject = draggedSubject;
+                    removeSubjectAndClones(draggedSubject.parentElement, parseFloat(draggedSubject.dataset.length), draggedSubject.dataset.subjectId);
+                } else if (isSubjectInTimetable) {
+                    // if the subject is in the timetable, but we're trying to add it again
+                    this.classList.remove('hovered');
+                    return;
                 } else {
-                    break;
+                    // if it's a new subject being added to the timetable
+                    newSubject = document.createElement('div');
+                    newSubject.className = draggedSubject.className;
+                    newSubject.classList.add('dropped-subject');
+                    newSubject.dataset.subjectId = draggedSubject.dataset.subjectId;
+                    newSubject.dataset.length = subjectLength.toString();
+
+                    // clone only p elements with class 'course_name' & 'course_stdg'
+                    draggedSubject.querySelectorAll('p.course_name, p.course_stdg').forEach(p => {
+                        newSubject.appendChild(p.cloneNode(true));
+                    });
+                }
+
+                if (newSubject === null) {
+                    return;
+                }
+
+                // Update the subject's time and day information
+                newSubject.dataset.startTime = startTime;
+                newSubject.dataset.endTime = endTime;
+                newSubject.dataset.day = day.toString();
+
+                // update or create the time span
+                let timeSpan = newSubject.querySelector('.time-span');
+                if (!timeSpan) {
+                    timeSpan = document.createElement('div');
+                    timeSpan.classList.add('time-span');
+                    newSubject.insertBefore(timeSpan, newSubject.firstChild);
+                }
+                timeSpan.textContent = `${startTime} - ${endTime}`;
+
+                this.appendChild(newSubject);
+                makeUnDraggable(draggedSubject);
+                makeDraggable(newSubject);
+
+                // create clones for multi-cell subjects
+                let currentCell = this;
+                for (let i = 1; i < subjectLength; i++) {
+                    currentCell = getNextCell(currentCell);
+                    if (currentCell) {
+                        const clone = newSubject.cloneNode(true);
+                        makeUnDraggable(clone)
+                        clone.classList.add('cloned');
+                        currentCell.appendChild(clone);
+                    } else {
+                        break;
+                    }
+                }
+
+                highlightOriginal(newSubject);
+            }
+
+            this.classList.remove('hovered');
+        }
+
+        /**
+         * Checks if a cell is a valid drop target for a subject of a given length.
+         * @param {HTMLElement} cell - The cell to check.
+         * @param {number} length - The length of the subject.
+         * @returns {boolean} - Whether the cell is a valid drop target.
+         */
+        function isValidDropTarget(cell, length) {
+            const cellIndex = Array.from(timetableCells).indexOf(cell);
+            const colIndex = cellIndex % 7;
+
+            if (colIndex === 0) {
+                return false;
+            }
+
+            let remainingLength = length;
+            let currentCell = cell;
+            while (remainingLength > 0 && currentCell) {
+                const currentCellIndex = Array.from(timetableCells).indexOf(currentCell);
+                const currentColIndex = currentCellIndex % 7;
+
+                if (currentColIndex === 0) {
+                    currentCell = getNextCell(currentCell);
+                    continue;
+                }
+
+                const existingSubject = currentCell.querySelector('.dropped-subject');
+                if (existingSubject && parseFloat(existingSubject.dataset.length) > 1) {
+                    remainingLength--;
+                } else if (!currentCell.classList.contains('blocked')) {
+                    remainingLength--;
+                }
+                currentCell = getNextCell(currentCell);
+            }
+
+            return remainingLength === 0;
+        }
+
+        /**
+         * Returns the next cell in the timetable.
+         * @param {Element} cell - The current cell.
+         * @returns {HTMLElement|null} - The next cell in the timetable, or null if there is no next cell.
+         */
+        function getNextCell(cell) {
+            const cellIndex = Array.from(timetableCells).indexOf(cell);
+            const rowIndex = Math.floor(cellIndex / 7);
+            const nextRowIndex = rowIndex + 1;
+
+            if (nextRowIndex * 7 >= timetableCells.length) {
+                return null;
+            } else {
+                return timetableCells[nextRowIndex * 7 + (cellIndex % 7)];
+            }
+        }
+
+        /**
+         * Returns the start time, end time, and day for a given cell and subject length.
+         * @param {HTMLElement} cell - The cell.
+         * @param {number} length - The length of the subject.
+         * @returns {Object} - An object containing the start time, end time, and day.
+         */
+        function getTimeAndDayFromCell(cell, length) {
+            const cellIndex = Array.from(timetableCells).indexOf(cell);
+            const row = cell.parentElement;
+            const startTimeText = row.querySelector('td:first-child').textContent.split(' - ')[0];
+            const endTimeText = calculateEndTime(startTimeText, length);
+            const day = cellIndex - 1;
+            return { startTime: startTimeText, endTime: endTimeText, day };
+        }
+
+        /**
+         * Calculates the end time for a subject given its start time and length.
+         * @param {string} startTime - The start time of the subject.
+         * @param {number} length - The length of the subject.
+         * @returns {string} - The end time of the subject.
+         */
+        function calculateEndTime(startTime, length) {
+            const [startHour, startMinute] = startTime.split(':').map(Number);
+
+            let additionalMinutes = 0;
+            if (length === 2) {
+                additionalMinutes = 15;
+            } else if (length === 3) {
+                additionalMinutes = 30;
+            } else if (length > 3) {
+                additionalMinutes = 45 * (length - 1);
+            }
+
+            let totalMinutes = startMinute + (length * 90) + additionalMinutes;
+            if (length === 2 && startTime === '11:45') {
+                totalMinutes += 45;
+            }
+            let endHour = startHour + Math.floor(totalMinutes / 60);
+            let endMinute = totalMinutes % 60;
+
+            if (endMinute < 10) {
+                endMinute = '0' + endMinute;
+            }
+
+            return `${endHour}:${endMinute}`;
+        }
+
+        /**
+         * Highlights the original subject element and removes the highlight from all other subjects.
+         * @param {HTMLElement} subjectElement - The subject element to highlight.
+         */
+        function highlightOriginal(subjectElement) {
+            subjects.forEach(subject => {
+                subject.classList.remove('highlighted');
+            });
+            subjectElement.classList.add('highlighted');
+        }
+
+        /**
+         * Removes a subject element from its parent cell and unblocks the cells it occupied.
+         * @param {HTMLElement} subjectElement - The subject element to remove.
+         */
+        function removeModule(subjectElement) {
+            const subjectId = subjectElement.dataset.subjectId;
+            const parentCell = subjectElement.parentElement;
+            const subjectLength = parseFloat(subjectElement.dataset.length);
+
+            removeSubjectAndClones(parentCell, subjectLength, subjectId);
+
+            // enable draggable for the original subject
+            const originalSubject = document.querySelector(`.subject[data-subject-id="${subjectId}"]`);
+            makeDraggable(originalSubject);
+        }
+
+        /**
+         * Removes a subject and its clones from a cell and unblocks the cells they occupied.
+         * @param {Element} cell - The cell to remove the subject and its clones from.
+         * @param {number} length - The length of the subject.
+         * @param subjectId
+         */
+        function removeSubjectAndClones(cell, length, subjectId) {
+            let currentCell = cell;
+            let removedSubjects = 0;
+
+            while (removedSubjects < length && currentCell) {
+                const subjects = currentCell.querySelectorAll('.dropped-subject, .cloned');
+                subjects.forEach(subject => {
+                    if (subject.dataset.subjectId === subjectId) {
+                        currentCell.removeChild(subject);
+                        removedSubjects++;
+                    }
+                });
+                currentCell = getNextCell(currentCell);
+            }
+        }
+
+        function checkIfSubjectIsInTimetable(subjectId) {
+            const subjects = document.querySelectorAll('.dropped-subject');
+            for (let i = 0; i < subjects.length; i++) {
+                if (subjects[i].dataset.subjectId === subjectId) {
+                    return true;
                 }
             }
-
-            highlightOriginal(newSubject);
-        }
-
-        this.classList.remove('hovered');
-    }
-
-    /**
-     * Checks if a cell is a valid drop target for a subject of a given length.
-     * @param {HTMLElement} cell - The cell to check.
-     * @param {number} length - The length of the subject.
-     * @returns {boolean} - Whether the cell is a valid drop target.
-     */
-    function isValidDropTarget(cell, length) {
-        const cellIndex = Array.from(timetableCells).indexOf(cell);
-        const colIndex = cellIndex % 7;
-
-        if (colIndex === 0) {
             return false;
         }
-
-        let remainingLength = length;
-        let currentCell = cell;
-        while (remainingLength > 0 && currentCell) {
-            const currentCellIndex = Array.from(timetableCells).indexOf(currentCell);
-            const currentColIndex = currentCellIndex % 7;
-
-            if (currentColIndex === 0) {
-                currentCell = getNextCell(currentCell);
-                continue;
-            }
-
-            const existingSubject = currentCell.querySelector('.dropped-subject');
-            if (existingSubject && parseFloat(existingSubject.dataset.length) > 1) {
-                remainingLength--;
-            } else if (!currentCell.classList.contains('blocked')) {
-                remainingLength--;
-            }
-            currentCell = getNextCell(currentCell);
-        }
-
-        return remainingLength === 0;
-    }
-
-    /**
-     * Returns the next cell in the timetable.
-     * @param {Element} cell - The current cell.
-     * @returns {HTMLElement|null} - The next cell in the timetable, or null if there is no next cell.
-     */
-    function getNextCell(cell) {
-        const cellIndex = Array.from(timetableCells).indexOf(cell);
-        const rowIndex = Math.floor(cellIndex / 7);
-        const nextRowIndex = rowIndex + 1;
-
-        if (nextRowIndex * 7 >= timetableCells.length) {
-            return null;
-        } else {
-            return timetableCells[nextRowIndex * 7 + (cellIndex % 7)];
-        }
-    }
-
-    /**
-     * Returns the start time, end time, and day for a given cell and subject length.
-     * @param {HTMLElement} cell - The cell.
-     * @param {number} length - The length of the subject.
-     * @returns {Object} - An object containing the start time, end time, and day.
-     */
-    function getTimeAndDayFromCell(cell, length) {
-        const cellIndex = Array.from(timetableCells).indexOf(cell);
-        const row = cell.parentElement;
-        const startTimeText = row.querySelector('td:first-child').textContent.split(' - ')[0];
-        const endTimeText = calculateEndTime(startTimeText, length);
-        const day = cellIndex - 1;
-        return { startTime: startTimeText, endTime: endTimeText, day };
-    }
-
-    /**
-     * Calculates the end time for a subject given its start time and length.
-     * @param {string} startTime - The start time of the subject.
-     * @param {number} length - The length of the subject.
-     * @returns {string} - The end time of the subject.
-     */
-    function calculateEndTime(startTime, length) {
-        const [startHour, startMinute] = startTime.split(':').map(Number);
-
-        let additionalMinutes = 0;
-        if (length === 2) {
-            additionalMinutes = 15;
-        } else if (length === 3) {
-            additionalMinutes = 30;
-        } else if (length > 3) {
-            additionalMinutes = 45 * (length - 1);
-        }
-
-        let totalMinutes = startMinute + (length * 90) + additionalMinutes;
-        if (length === 2 && startTime === '11:45') {
-            totalMinutes += 45;
-        }
-        let endHour = startHour + Math.floor(totalMinutes / 60);
-        let endMinute = totalMinutes % 60;
-
-        if (endMinute < 10) {
-            endMinute = '0' + endMinute;
-        }
-
-        return `${endHour}:${endMinute}`;
-    }
-
-    /**
-     * Highlights the original subject element and removes the highlight from all other subjects.
-     * @param {HTMLElement} subjectElement - The subject element to highlight.
-     */
-    function highlightOriginal(subjectElement) {
-        subjects.forEach(subject => {
-            subject.classList.remove('highlighted');
-        });
-        subjectElement.classList.add('highlighted');
-    }
-
-    /**
-     * Removes a subject element from its parent cell and unblocks the cells it occupied.
-     * @param {HTMLElement} subjectElement - The subject element to remove.
-     */
-    function removeModule(subjectElement) {
-        const subjectId = subjectElement.dataset.subjectId;
-        const parentCell = subjectElement.parentElement;
-        const subjectLength = parseFloat(subjectElement.dataset.length);
-
-        removeSubjectAndClones(parentCell, subjectLength, subjectId);
-
-        // enable draggable for the original subject
-        const originalSubject = document.querySelector(`.subject[data-subject-id="${subjectId}"]`);
-        makeDraggable(originalSubject);
-    }
-
-    /**
-     * Removes a subject and its clones from a cell and unblocks the cells they occupied.
-     * @param {Element} cell - The cell to remove the subject and its clones from.
-     * @param {number} length - The length of the subject.
-     * @param subjectId
-     */
-    function removeSubjectAndClones(cell, length, subjectId) {
-        let currentCell = cell;
-        let removedSubjects = 0;
-
-        while (removedSubjects < length && currentCell) {
-            const subjects = currentCell.querySelectorAll('.dropped-subject, .cloned');
-            subjects.forEach(subject => {
-                if (subject.dataset.subjectId === subjectId) {
-                    currentCell.removeChild(subject);
-                    removedSubjects++;
-                }
-            });
-            currentCell = getNextCell(currentCell);
-        }
-    }
-
-    function checkIfSubjectIsInTimetable(subjectId) {
-        const subjects = document.querySelectorAll('.dropped-subject');
-        for (let i = 0; i < subjects.length; i++) {
-            if (subjects[i].dataset.subjectId === subjectId) {
-                return true;
-            }
-        }
-        return false;
     }
 });

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -1,21 +1,29 @@
 <!--suppress HtmlUnknownAttribute -->
+<!--suppress HtmlUnknownTag -->
 <nav x-data="{ open: false }" class="bg-white border-b border-gray-100">
-    <!-- Primary Navigation Menu -->
+    {{-- Primary Navigation Menu --}}
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex justify-between h-16">
             <div class="flex">
-                <!-- Logo -->
+                {{-- Logo --}}
                 <div class="shrink-0 flex items-center">
                     <a href="{{ route('dashboard') }}">
                         <x-application-logo class="block h-9 w-auto fill-current text-gray-800" />
                     </a>
                 </div>
 
-                <!-- Navigation Links -->
+                {{-- Navigation Links --}}
                 <div class="hidden space-x-4 sm:-my-px sm:ms-10 md:flex">
                     <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                         {{ __('Dashboard') }}
                     </x-nav-link>
+                    {{-- check if user has a dozent --}}
+                    @if (Auth::user()->dozent)
+                        <x-nav-link :href="route('stundenplan.show')" :active="request()->routeIs('stundenplan.show')">
+                            {{ __('Mein Stundenplan') }}
+                        </x-nav-link>
+                    @endif
+
                     @if (Auth::user()->admin)
                         {{-- only show link if user is admin, only admins should be able to create new users, lecturers & courses --}}
                         <x-nav-link :href="route('users.index')" :active="request()->routeIs('users.index')">
@@ -31,14 +39,12 @@
                 </div>
             </div>
 
-            <!-- Settings Dropdown -->
+            {{-- Settings Dropdown --}}
             <div class="hidden md:flex sm:items-center sm:ms-6">
                 <x-dropdown align="right" width="48">
                     <x-slot name="trigger">
                         <button class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 bg-white hover:text-gray-700 focus:outline-none transition ease-in-out duration-150">
-                            <!--suppress HtmlUnknownTag -->
                             <div>{{ Auth::user()->name }}</div>
-                            <!--suppress HtmlUnknownTag -->
                             <div class="ms-1">
                                 <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
                                     <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
@@ -52,7 +58,7 @@
                             {{ __('Profile') }}
                         </x-dropdown-link>
 
-                        <!-- Authentication -->
+                        {{-- Authentication --}}
                         <form method="POST" action="{{ route('logout') }}">
                             @csrf
 
@@ -66,9 +72,8 @@
                 </x-dropdown>
             </div>
 
-            <!-- Hamburger -->
+            {{-- Hamburger --}}
             <div class="-me-2 flex items-center md:hidden">
-                <!--suppress HtmlUnknownAttribute -->
                 <button @click="open = ! open" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 focus:text-gray-500 transition duration-150 ease-in-out">
                     <svg class="h-6 w-6" stroke="currentColor" fill="none" viewBox="0 0 24 24">
                         <path :class="{'hidden': open, 'inline-flex': ! open }" class="inline-flex" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
@@ -79,8 +84,8 @@
         </div>
     </div>
 
-    <!-- Responsive Navigation Menu -->
-    <!--suppress HtmlUnknownAttribute -->
+    {{-- Responsive Navigation Menu --}}
+    {{--suppress HtmlUnknownAttribute --}}
     <div :class="{'block': open, 'hidden': ! open}" class="hidden md:hidden">
         <div class="pt-2 pb-3 space-y-1">
             <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
@@ -103,7 +108,7 @@
             @endif
         </div>
 
-        <!-- Responsive Settings Options -->
+        {{-- Responsive Settings Options --}}
         <div class="pt-4 pb-1 border-t border-gray-200">
             <div class="px-4">
                 <div class="font-medium text-base text-gray-800">{{ Auth::user()->name }}</div>
@@ -115,7 +120,7 @@
                     {{ __('Profile') }}
                 </x-responsive-nav-link>
 
-                <!-- Authentication -->
+                {{-- Authentication --}}
                 <form method="POST" action="{{ route('logout') }}">
                     @csrf
 

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -92,6 +92,13 @@
                 {{ __('Dashboard') }}
             </x-responsive-nav-link>
 
+            {{-- check if user has a dozent --}}
+            @if (Auth::user()->dozent)
+                <x-responsive-nav-link :href="route('stundenplan.show')" :active="request()->routeIs('stundenplan.show')">
+                    {{ __('Mein Stundenplan') }}
+                </x-responsive-nav-link>
+            @endif
+
             @if (Auth::user()->admin)
                 {{-- only show link if user is admin, only admins should be able to create new users, lecturers & courses --}}
                 <x-responsive-nav-link :href="route('users.index')" :active="request()->routeIs('users.index')">

--- a/resources/views/stundenplan/plan_doz.blade.php
+++ b/resources/views/stundenplan/plan_doz.blade.php
@@ -1,0 +1,59 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Mein Stundenplan') }}
+        </h2>
+    </x-slot>
+
+    @include('components.status-msg')
+
+    <div class="py-12 relative">
+        <div class="max-w-screen-2xl mx-auto sm:px-6 lg:px-8 fixed timetable_page w-full">
+            <aside class="sidebar">
+                <div class="sidebar_header">
+                    <h2 class="font-bold text-lg">{{ __('Fächerwahl') }}</h2>
+                    {{--
+                    <svg xmlns="http://www.w3.org/2000/svg" width="35" height="35" viewBox="0 0 57.802 57.802">
+                        <path id="block_24dp_FILL0_wght400_GRAD0_opsz24"
+                              d="M108.9-822.2a28.143,28.143,0,0,1-11.271-2.276,29.186,29.186,0,0,1-9.176-6.178,29.185,29.185,0,0,1-6.178-9.176A28.143,28.143,0,0,1,80-851.1a28.142,28.142,0,0,1,2.276-11.271,29.186,29.186,0,0,1,6.178-9.176,29.187,29.187,0,0,1,9.176-6.178A28.143,28.143,0,0,1,108.9-880a28.143,28.143,0,0,1,11.271,2.276,29.187,29.187,0,0,1,9.176,6.178,29.186,29.186,0,0,1,6.178,9.176A28.143,28.143,0,0,1,137.8-851.1a28.143,28.143,0,0,1-2.276,11.271,29.185,29.185,0,0,1-6.178,9.176,29.186,29.186,0,0,1-9.176,6.178A28.143,28.143,0,0,1,108.9-822.2Zm0-5.78a22.582,22.582,0,0,0,7.514-1.264,22.977,22.977,0,0,0,6.647-3.649L90.693-865.26a22.977,22.977,0,0,0-3.649,6.647A22.582,22.582,0,0,0,85.78-851.1,22.314,22.314,0,0,0,92.5-834.7,22.314,22.314,0,0,0,108.9-827.978Zm18.208-8.959a22.977,22.977,0,0,0,3.649-6.647,22.582,22.582,0,0,0,1.264-7.514,22.314,22.314,0,0,0-6.719-16.4,22.314,22.314,0,0,0-16.4-6.719,22.582,22.582,0,0,0-7.514,1.264,22.977,22.977,0,0,0-6.647,3.649Z"
+                              transform="translate(-80 880)" fill="#393939" />
+                    </svg>
+                    --}}
+                </div>
+                <div class="sidebar_courses">
+                    @foreach(Auth::user()->dozent->kurse as $kurs)
+                        <div class="subject" draggable="true" data-length="{{ $kurs->sws / 2 }}" data-subject-id="{{ $kurs->id }}">
+                            <p class="course_name">{{ $kurs->kurs_name }}</p>
+                            <p class="course_stdg">{{ $kurs->studiengang->stdg_kürzel }} {{ $kurs->semester }}</p>
+                            <p class="course_sws">{{ $kurs->sws }} SWS</p>
+                        </div>
+                    @endforeach
+                </div>
+            </aside>
+        </div>
+        <div class="max-w-screen-2xl mx-auto sm:px-6 lg:px-8 timetable_page w-full">
+            <div class="timetable col-start-2">
+                <table class="timetable_content">
+                    <thead class="timetable_head">
+                        <tr>
+                            <th>{{ __('Uhrzeit') }}</th>
+                            @foreach ($days as $day)
+                                <th><?= $day ?></th>
+                            @endforeach
+                        </tr>
+                    </thead>
+                    <tbody>
+                    @foreach ($hours_pairs as $hours)
+                        <tr>
+                            <td><?= $hours[0] ?> - <?= $hours[1] ?></td>
+                            @foreach ($days as $i => $day)
+                                <td class="timetable_data" data-time="<?=$hours[0]?>" data-day="<?=$day?>"></td>
+                            @endforeach
+                        </tr>
+                    @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/stundenplan/plan_doz.blade.php
+++ b/resources/views/stundenplan/plan_doz.blade.php
@@ -45,7 +45,7 @@
                     <tbody>
                     @foreach ($hours_pairs as $hours)
                         <tr>
-                            <td><?= $hours[0] ?> - <?= $hours[1] ?></td>
+                            <td class="timetable_time"><?= $hours[0] ?> - <?= $hours[1] ?></td>
                             @foreach ($days as $i => $day)
                                 <td class="timetable_data" data-time="<?=$hours[0]?>" data-day="<?=$day?>"></td>
                             @endforeach

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,7 +5,9 @@ use App\Http\Controllers\KursController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\HomeController;
 use App\Http\Controllers\StudiengangController;
+use App\Http\Controllers\StundenController;
 use App\Http\Middleware\AdminMiddleware;
+use App\Http\Middleware\DozentMiddleware;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\UserDozController;
 
@@ -96,6 +98,14 @@ Route::middleware(['auth', AdminMiddleware::class])->group(function () {
     Route::get('/users', [UserDozController::class, 'index'])->name('users.index');
     Route::get('/kurse', [KursController::class, 'index'])->name('kurse.index');
     Route::get('/studiengänge', [StudiengangController::class, 'index'])->name('studiengänge.index');
+});
+
+Route::middleware(['auth', DozentMiddleware::class])->group(function () {
+    /**
+     * Show stundenplan of current dozent
+     */
+    Route::get('/stundenplan', [StundenController::class, 'index'])
+        ->name('stundenplan.show');
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
- merge [timetable HTML, CSS & JS](https://github.com/hsa-webeng/stundenplan-html) into laravel frontend
- add DozentMiddleware.php to allow for specified routes to be accessed by dozenten only
- add new route & nav item to open timetable frontend

## Styling

- restyle timetable
  - un-draggable courses are now marked as such
  - changed colour palette
  - set default height of timetable cells to prevent constant layout shifts
  - reduced amount of text in dropped courses

## JS

- timetable now only allows 1 course of each type
  - add function to check if a course is already in timetable
- add colour coding
  - alternating default colours to help identifying entries that belong together
  - colour coding for conflicts

> ### Disclaimer
> The entire JS script in this PR needs refactoring.
> Large JS parts of this PR were written by [Claude](https://claude.ai):
> 
> - [0a53613](https://github.com/hsa-webeng/stundenplan-laravel/pull/9/commits/0a53613b8bb7a7de41a92caa9650a858b5afc8ec): 
>   - moving course if it is already in timetable
>   - clone only specific p elements inside the course elements
>   - refactor `removeModule()` to use `removeSubjectAndClones()`
> - [a8e3155](https://github.com/hsa-webeng/stundenplan-laravel/pull/9/commits/a8e31554876fb42ec550ffee8f7798a1b5323a0c)
> - [6aebd74](https://github.com/hsa-webeng/stundenplan-laravel/pull/9/commits/6aebd740ea235497a98ec57ad1a0d84bd440039e)

![image](https://github.com/user-attachments/assets/b26ee00c-7239-41e2-833e-3982f494e5f4)
